### PR TITLE
develop: Pin alpine version to 3.6 and Python version to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Official Python base image is needed or some applications will segfault.
-FROM python:3.5-alpine
+FROM python:3.6-alpine3.6
 
 # PyInstaller needs zlib-dev, gcc, libc-dev, and musl-dev
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PyInstaller Alpine
+PyInstaller Alpine (Python 3.6)
 ==================
 
 Docker image that can build single file Python apps with
@@ -30,8 +30,8 @@ mounted as a volume at `/src`:
         --clean \
         example.py
 
-If a `requirements.txt` file is found in your source directory, the
-requirements will automatically be installed with `pip`.
+If either a `requirements.txt` or `setup.py` file is found in your source directory, the 
+requirements will automatically be installed with `pip`.        
 
 This will output a built app to the `dist` sub-directory in your source
 directory. The app can be ran on an Alpine OS:

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export PYINSTALLER_TAG=${1:-v3.3}
-export ALPINE_VERSION=${2:-v3.4}
+export ALPINE_VERSION=${2:-v3.6}
 
 REPO="six8/pyinstaller-alpine:alpine-${ALPINE_VERSION}-pyinstaller-${PYINSTALLER_TAG}"
 


### PR DESCRIPTION
It's coincidental that alpine latest is 3.6 and python latest is also 3.6, but hey.