### PR TITLE
Add external dependencies for python libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,25 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repos
         libxslt-dev \
         upx \
         postgresql-dev \
+        bash \
+        build-base \
+        freetype-dev \
+        fribidi-dev \
+        gfortran \
+        harfbuzz-dev \
+        jpeg-dev \
+        lcms2-dev \
+        openblas-dev \
+        openjpeg-dev \
+        openssl \
+        pkgconfig \
+        py2-pip \
+        python-dev \
+        sudo \
+        tcl-dev \
+        tiff-dev \
+        tk-dev \
+        zlib-dev \
     && pip install --upgrade pip
 
 # Install pycrypto so --key can be used with PyInstaller

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repos
         upx \
         zeromq-dev \
         zlib-dev \
-        zlib-dev \
     && pip install --upgrade pip
 
 # Install pycrypto so --key can be used with PyInstaller

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,37 +7,37 @@ FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
     && apk --update --no-cache add \
-        zlib-dev \
-        musl-dev \
-        libc-dev \
-        linux-headers \
-        g++ \
-        git \
-        pwgen \
-        zeromq-dev \
-        libzmq \
-        libxml2-dev \
-        libxslt-dev \
-        upx \
-        postgresql-dev \
         bash \
         build-base \
         freetype-dev \
         fribidi-dev \
+        g++ \
         gfortran \
+        git \
         harfbuzz-dev \
         jpeg-dev \
         lcms2-dev \
+        libc-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libzmq \
+        linux-headers \
+        musl-dev \
         openblas-dev \
         openjpeg-dev \
         openssl \
         pkgconfig \
+        postgresql-dev \
+        pwgen \
         py2-pip \
         python-dev \
         sudo \
         tcl-dev \
         tiff-dev \
         tk-dev \
+        upx \
+        zeromq-dev \
+        zlib-dev \
         zlib-dev \
     && pip install --upgrade pip
 


### PR DESCRIPTION
This pull request adds dependencies that are required to set up following libraries:

* numpy
* scipy
* scikit-learn
* pillow